### PR TITLE
Changed type hinting for handler function

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import ast
 import re
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence, SupportsAbs
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs
 
 from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook
@@ -221,7 +221,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         sql: str | list[str],
         autocommit: bool = False,
         parameters: Mapping | Iterable | None = None,
-        handler: Callable[[Any], Optional[list[tuple]]] = fetch_all_handler,
+        handler: Callable[[Any], list[tuple]] | None = fetch_all_handler,
         conn_id: str | None = None,
         database: str | None = None,
         split_statements: bool | None = None,

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import ast
 import re
 from functools import cached_property
-+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence, SupportsAbs
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence, SupportsAbs
 
 from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -221,7 +221,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         sql: str | list[str],
         autocommit: bool = False,
         parameters: Mapping | Iterable | None = None,
-        handler: Callable[[Any], Iterable[Tuple]] = fetch_all_handler,
+        handler: Callable[[Any], Iterable[tuple]] = fetch_all_handler,
         conn_id: str | None = None,
         database: str | None = None,
         split_statements: bool | None = None,

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -221,7 +221,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         sql: str | list[str],
         autocommit: bool = False,
         parameters: Mapping | Iterable | None = None,
-        handler: Callable[[Any], list[tuple]] = fetch_all_handler,
+        handler: Callable[[Any], Optional[list[tuple]]] = fetch_all_handler,
         conn_id: str | None = None,
         database: str | None = None,
         split_statements: bool | None = None,

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -221,7 +221,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         sql: str | list[str],
         autocommit: bool = False,
         parameters: Mapping | Iterable | None = None,
-        handler: Callable[[Any], list[tuple]] | None = fetch_all_handler,
+        handler: Callable[[Any], list[tuple] | None] = fetch_all_handler,
         conn_id: str | None = None,
         database: str | None = None,
         split_statements: bool | None = None,

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import ast
 import re
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs, Optional
 
 from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import ast
 import re
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs, Optional
++from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence, SupportsAbs
 
 from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import ast
 import re
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs, Tuple
 
 from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook
@@ -221,7 +221,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         sql: str | list[str],
         autocommit: bool = False,
         parameters: Mapping | Iterable | None = None,
-        handler: Callable[[Any], Any] = fetch_all_handler,
+        handler: Callable[[Any], Iterable[Tuple]] = fetch_all_handler,
         conn_id: str | None = None,
         database: str | None = None,
         split_statements: bool | None = None,

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import ast
 import re
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs
 
 from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook
@@ -221,7 +221,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         sql: str | list[str],
         autocommit: bool = False,
         parameters: Mapping | Iterable | None = None,
-        handler: Callable[[Any], Iterable[tuple]] = fetch_all_handler,
+        handler: Callable[[Any], list[tuple]] = fetch_all_handler,
         conn_id: str | None = None,
         database: str | None = None,
         split_statements: bool | None = None,

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -47,7 +47,7 @@ from airflow.providers.openlineage.extractors import OperatorLineage as Operator
 from airflow.utils.context import Context as Context
 from airflow.utils.helpers import merge_dicts as merge_dicts
 from functools import cached_property as cached_property
-from typing import Any, Callable, Iterable, Mapping, Sequence, SupportsAbs
+from typing import Any, Callable, Iterable, Mapping, Sequence, SupportsAbs, Optional
 
 def _parse_boolean(val: str) -> str | bool: ...
 def parse_boolean(val: str) -> str | bool: ...

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -89,7 +89,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         sql: str | list[str],
         autocommit: bool = False,
         parameters: Mapping | Iterable | None = None,
-        handler: Callable[[Any], Any] = ...,
+        handler: Callable[[Any], list[tuple]] = ...,
         conn_id: str | None = None,
         database: str | None = None,
         split_statements: bool | None = None,

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -47,7 +47,7 @@ from airflow.providers.openlineage.extractors import OperatorLineage as Operator
 from airflow.utils.context import Context as Context
 from airflow.utils.helpers import merge_dicts as merge_dicts
 from functools import cached_property as cached_property
-+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence, SupportsAbs
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence, SupportsAbs
 
 def _parse_boolean(val: str) -> str | bool: ...
 def parse_boolean(val: str) -> str | bool: ...

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -47,7 +47,7 @@ from airflow.providers.openlineage.extractors import OperatorLineage as Operator
 from airflow.utils.context import Context as Context
 from airflow.utils.helpers import merge_dicts as merge_dicts
 from functools import cached_property as cached_property
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence, SupportsAbs
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs
 
 def _parse_boolean(val: str) -> str | bool: ...
 def parse_boolean(val: str) -> str | bool: ...
@@ -89,7 +89,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         sql: str | list[str],
         autocommit: bool = False,
         parameters: Mapping | Iterable | None = None,
-        handler: Callable[[Any], Optional[list[tuple]]] = ...,
+        handler: Callable[[Any], list[tuple] | None] = ...,
         conn_id: str | None = None,
         database: str | None = None,
         split_statements: bool | None = None,

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -89,7 +89,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         sql: str | list[str],
         autocommit: bool = False,
         parameters: Mapping | Iterable | None = None,
-        handler: Callable[[Any], list[tuple]] = ...,
+        handler: Callable[[Any], Optional[list[tuple]]] = ...,
         conn_id: str | None = None,
         database: str | None = None,
         split_statements: bool | None = None,

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -47,7 +47,7 @@ from airflow.providers.openlineage.extractors import OperatorLineage as Operator
 from airflow.utils.context import Context as Context
 from airflow.utils.helpers import merge_dicts as merge_dicts
 from functools import cached_property as cached_property
-from typing import Any, Callable, Iterable, Mapping, Sequence, SupportsAbs, Optional
++from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence, SupportsAbs
 
 def _parse_boolean(val: str) -> str | bool: ...
 def parse_boolean(val: str) -> str | bool: ...

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -47,7 +47,7 @@ from airflow.providers.openlineage.extractors import OperatorLineage as Operator
 from airflow.utils.context import Context as Context
 from airflow.utils.helpers import merge_dicts as merge_dicts
 from functools import cached_property as cached_property
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, NoReturn, Sequence, SupportsAbs
+from typing import Any, Callable, Iterable, Mapping, Sequence, SupportsAbs
 
 def _parse_boolean(val: str) -> str | bool: ...
 def parse_boolean(val: str) -> str | bool: ...


### PR DESCRIPTION

Due to changes introduced in https://github.com/apache/airflow/pull/36205, we experienced breakage in our SQLExecuteQueryOperator. In short, our assumption was that the handler is able to also transform the data type returned from the query. For example our handler looked something like this:
```python
def custom_handler(cursor):
    results = fetch_all_handler(cursor)
    columns = [column[0] for column in cursor.description]
     result_dicts = [dict(zip(columns, record)) for record in results]
     return [SomeDataclass(col_a=d[“COL_A”]
```
As that was changed, that led to errors in our dags. We now moved to use the  `_process_output` method as we should’ve done in the first place, but we this type hint will prevent further confusion as to what are the constraints of the handler passed to the operator. 